### PR TITLE
add /feeds page with OPML builder for speaker RSS feeds

### DIFF
--- a/bin/latest-posts.mjs
+++ b/bin/latest-posts.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from 'fs/promises';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FEEDS = path.join(__dirname, '..', 'src', '_data', 'feeds.json');
+const OUT = path.join(__dirname, '..', 'src', '_data', 'latestPosts.json');
+
+const USER_AGENT = 'FFConfFeedBot/1.0 (+https://ffconf.org/feeds)';
+const TIMEOUT_MS = 10000;
+const CONCURRENCY = 6;
+
+const decodeEntities = (s = '') =>
+  s
+    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCodePoint(parseInt(h, 16)))
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .trim();
+
+function firstMatch(block, tag) {
+  const re = new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)<\\/${tag}>`, 'i');
+  const m = block.match(re);
+  return m ? decodeEntities(m[1]) : null;
+}
+
+function firstAttr(block, tag, attr) {
+  const re = new RegExp(`<${tag}\\b[^>]*\\b${attr}\\s*=\\s*"([^"]+)"`, 'i');
+  const m = block.match(re);
+  return m ? decodeEntities(m[1]) : null;
+}
+
+function parseLatest(xml) {
+  const isAtom = /<feed\b[^>]*xmlns=["']http:\/\/www\.w3\.org\/2005\/Atom/i.test(xml);
+  const entryTag = isAtom ? 'entry' : 'item';
+  const re = new RegExp(`<${entryTag}\\b[^>]*>([\\s\\S]*?)<\\/${entryTag}>`, 'i');
+  const m = xml.match(re);
+  if (!m) return null;
+  const block = m[1];
+
+  const title = firstMatch(block, 'title') || '';
+  let url = null;
+  if (isAtom) {
+    const altHref = block.match(
+      /<link\b[^>]*rel=["']alternate["'][^>]*href=["']([^"']+)["']/i
+    );
+    url =
+      (altHref && decodeEntities(altHref[1])) ||
+      firstAttr(block, 'link', 'href') ||
+      firstMatch(block, 'id');
+  } else {
+    url =
+      firstMatch(block, 'link') ||
+      firstAttr(block, 'link', 'href') ||
+      firstMatch(block, 'guid');
+  }
+
+  const dateRaw =
+    firstMatch(block, 'pubDate') ||
+    firstMatch(block, 'published') ||
+    firstMatch(block, 'updated') ||
+    firstMatch(block, 'dc:date') ||
+    firstMatch(block, 'date') ||
+    null;
+
+  let date = null;
+  if (dateRaw) {
+    const d = new Date(dateRaw);
+    if (!isNaN(d.getTime())) date = d.toISOString();
+  }
+
+  if (!title || !url) return null;
+  return { title: title.replace(/\s+/g, ' ').trim(), url: url.trim(), date };
+}
+
+async function fetchWithTimeout(url) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      signal: ctrl.signal,
+      redirect: 'follow',
+      headers: {
+        'User-Agent': USER_AGENT,
+        Accept: 'application/atom+xml, application/rss+xml, application/xml;q=0.9, */*;q=0.8',
+      },
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return await res.text();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function runPool(items, worker, size) {
+  const results = [];
+  let i = 0;
+  const run = async () => {
+    while (i < items.length) {
+      const idx = i++;
+      results[idx] = await worker(items[idx], idx);
+    }
+  };
+  await Promise.all(Array.from({ length: size }, run));
+  return results;
+}
+
+async function main() {
+  const feeds = JSON.parse(await readFile(FEEDS, 'utf8'));
+
+  let existing = {};
+  try {
+    existing = JSON.parse(await readFile(OUT, 'utf8'));
+  } catch {}
+
+  const fetchedAt = new Date().toISOString();
+  const out = {};
+  let ok = 0;
+  let fail = 0;
+
+  const fmt = (ms) => `${Math.round(ms).toString().padStart(4)}ms`;
+
+  await runPool(
+    feeds,
+    async (entry) => {
+      const label = entry.name.padEnd(24);
+      const tFetchStart = performance.now();
+      try {
+        const xml = await fetchWithTimeout(entry.feed);
+        const fetchMs = performance.now() - tFetchStart;
+        const latest = parseLatest(xml);
+        if (!latest) throw new Error('no entry parsed');
+        out[entry.feed] = { ...latest, fetchedAt };
+        ok++;
+        console.log(`✓ ${label} ${fmt(fetchMs)}  ${latest.title.slice(0, 60)}`);
+      } catch (err) {
+        fail++;
+        const elapsed = performance.now() - tFetchStart;
+        if (existing[entry.feed]) {
+          out[entry.feed] = existing[entry.feed];
+          console.log(`· ${label} ${fmt(elapsed)}  kept cached (${err.message})`);
+        } else {
+          console.log(`✗ ${label} ${fmt(elapsed)}  ${err.message}`);
+        }
+      }
+    },
+    CONCURRENCY
+  );
+
+  await writeFile(OUT, JSON.stringify(out, null, 2) + '\n');
+  console.log(`\nWrote ${Object.keys(out).length} entries to ${path.relative(process.cwd(), OUT)} (${ok} fresh, ${fail} failed)`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "server": "PORT=3333 node ./graphql/server",
     "dev": "eleventy --serve --quiet",
     "jobs": "node ./jobs.mjs",
+    "latest-posts": "node ./bin/latest-posts.mjs",
     "redirects": "node ./redirects.js",
     "prebuild": "npm run jobs",
     "build": "eleventy && npm run redirects && test -e dist/index.html"

--- a/src/_data/feeds.json
+++ b/src/_data/feeds.json
@@ -1,0 +1,392 @@
+[
+  {
+    "name": "Ada Rose Edwards",
+    "homepage": "https://ada.is/",
+    "feed": "https://ada.is/feed"
+  },
+  {
+    "name": "Addy Osmani",
+    "homepage": "https://addyosmani.com/",
+    "feed": "http://addyosmani.com/rss.xml"
+  },
+  {
+    "name": "Alex Russell",
+    "homepage": "https://infrequently.org/",
+    "feed": "https://infrequently.org/feed/"
+  },
+  {
+    "name": "Alice Bartlett",
+    "homepage": "https://alicebartlett.co.uk/",
+    "feed": "https://alicebartlett.co.uk/feed.xml"
+  },
+  {
+    "name": "Amber Shand",
+    "homepage": "https://www.ambershand.co.uk/",
+    "feed": "https://www.ambershand.co.uk/blog/rss.xml"
+  },
+  {
+    "name": "Amy Hupe",
+    "homepage": "https://amyhupe.co.uk/",
+    "feed": "https://amyhupe.co.uk/atom.xml"
+  },
+  {
+    "name": "Ana Rodrigues",
+    "homepage": "https://ohhelloana.blog/",
+    "feed": "https://ohhelloana.blog/feed.xml"
+  },
+  {
+    "name": "Andrew Betts",
+    "homepage": "https://trib.tv/",
+    "feed": "https://trib.tv/feed"
+  },
+  {
+    "name": "Andrew Nesbitt",
+    "homepage": "https://nesbitt.io/",
+    "feed": "https://nesbitt.io/feed.xml"
+  },
+  {
+    "name": "Andy Bell",
+    "homepage": "https://bell.bz/",
+    "feed": "https://bell.bz/feed.xml"
+  },
+  {
+    "name": "Andy Wingo",
+    "homepage": "https://wingolog.org/",
+    "feed": "https://wingolog.org/feed"
+  },
+  {
+    "name": "Angela Ricci",
+    "homepage": "https://gericci.me/",
+    "feed": "https://gericci.me/feed.xml"
+  },
+  {
+    "name": "Angus Croll",
+    "homepage": "https://javascriptweblog.wordpress.com/",
+    "feed": "https://javascriptweblog.wordpress.com/feed/"
+  },
+  {
+    "name": "Anna Shipman",
+    "homepage": "https://www.annashipman.co.uk/",
+    "feed": "https://www.annashipman.co.uk/atom.xml"
+  },
+  {
+    "name": "Asim Hussain",
+    "homepage": "https://asim.dev/",
+    "feed": "https://goteoc.substack.com/feed"
+  },
+  {
+    "name": "Ben Foxall",
+    "homepage": "https://benjaminbenben.com/",
+    "feed": "https://benjaminbenben.com/atom.xml"
+  },
+  {
+    "name": "Blaine Cook",
+    "homepage": "https://bcook.ca/",
+    "feed": "https://bcook.ca/feed/"
+  },
+  {
+    "name": "Brendan Dawes",
+    "homepage": "https://brendandawes.com/",
+    "feed": "http://brendandawes.com/blog/feed"
+  },
+  {
+    "name": "Bruce Lawson",
+    "homepage": "https://brucelawson.co.uk/",
+    "feed": "https://brucelawson.co.uk/feed/"
+  },
+  {
+    "name": "Caolan McMahon",
+    "homepage": "https://caolan.uk/",
+    "feed": "https://caolan.uk/feed/notes/"
+  },
+  {
+    "name": "Charlie Owen",
+    "homepage": "https://awfulwoman.com/",
+    "feed": "https://awfulwoman.com/index.xml"
+  },
+  {
+    "name": "Charlotte Dann",
+    "homepage": "https://charlottedann.com/",
+    "feed": "https://charlottedann.com/rss.xml"
+  },
+  {
+    "name": "Chris Wilson",
+    "homepage": "https://cwilso.com/",
+    "feed": "https://cwilso.com/feed/"
+  },
+  {
+    "name": "Christian Heilmann",
+    "homepage": "https://christianheilmann.com/",
+    "feed": "https://christianheilmann.com/feed/"
+  },
+  {
+    "name": "Dan Webb",
+    "homepage": "https://danwebb.net/",
+    "feed": "https://danwebb.net/feed.xml"
+  },
+  {
+    "name": "Florence Okoye",
+    "homepage": "https://finokoye.com/",
+    "feed": "https://finokoye.com/feed/"
+  },
+  {
+    "name": "Hannah Wolfe",
+    "homepage": "https://hannah.wf/",
+    "feed": "https://hannah.wf/rss/"
+  },
+  {
+    "name": "Harry Roberts",
+    "homepage": "https://csswizardry.com/",
+    "feed": "https://csswizardry.com/feed"
+  },
+  {
+    "name": "Henrik Joreteg",
+    "homepage": "https://joreteg.com/",
+    "feed": "https://joreteg.com/rss"
+  },
+  {
+    "name": "Heydon Pickering",
+    "homepage": "https://heydonworks.com/",
+    "feed": "https://heydonworks.com/feed"
+  },
+  {
+    "name": "Ire Aderinokun",
+    "homepage": "https://bitsofco.de/",
+    "feed": "https://bitsofco.de/feed/feed.xml"
+  },
+  {
+    "name": "Jake Archibald",
+    "homepage": "https://jakearchibald.com/",
+    "feed": "https://jakearchibald.com/posts.rss"
+  },
+  {
+    "name": "Jan Lehnardt",
+    "homepage": "https://jan.prima.de/",
+    "feed": "https://writing.jan.io/feed.xml"
+  },
+  {
+    "name": "Jenn Schiffer",
+    "homepage": "https://jennschiffer.com/",
+    "feed": "https://livelaugh.blog/rss.xml"
+  },
+  {
+    "name": "Jeremy Keith",
+    "homepage": "https://adactio.com/",
+    "feed": "https://adactio.com/journal/rss"
+  },
+  {
+    "name": "Jessica Rose & Eda Eren",
+    "homepage": "https://jessica.tech/",
+    "feed": "https://jessica.tech/feed.xml"
+  },
+  {
+    "name": "Joe Hart",
+    "homepage": "https://www.joehart.co.uk/",
+    "feed": "https://www.joehart.co.uk/feed.xml"
+  },
+  {
+    "name": "John Allsopp",
+    "homepage": "https://johnfallsopp.com/",
+    "feed": "https://webdirections.org/category/blog/feed/"
+  },
+  {
+    "name": "John K. Paul",
+    "homepage": "https://johnkpaul.com/",
+    "feed": "https://johnkpaul.com/atom.xml"
+  },
+  {
+    "name": "Jonathan Fielding",
+    "homepage": "https://www.jonathanfielding.com/",
+    "feed": "https://medium.com/feed/@jonthanfielding"
+  },
+  {
+    "name": "Kenneth Auchenberg",
+    "homepage": "https://kenneth.io/",
+    "feed": "https://kenneth.io/api/feed.xml"
+  },
+  {
+    "name": "Kimberley Cook",
+    "homepage": "https://builtby.kim/",
+    "feed": "https://builtby.kim/feed.xml"
+  },
+  {
+    "name": "Lex Lofthouse",
+    "homepage": "https://loftio.co.uk/",
+    "feed": "https://loftio.co.uk/feed/"
+  },
+  {
+    "name": "Lisi Linhart",
+    "homepage": "https://lisilinhart.info/",
+    "feed": "https://lisilinhart.info/feed.xml"
+  },
+  {
+    "name": "Léonie Watson",
+    "homepage": "https://tink.uk/",
+    "feed": "https://tink.uk/feed.xml"
+  },
+  {
+    "name": "Maggie Appleton",
+    "homepage": "https://maggieappleton.com/",
+    "feed": "https://maggieappleton.com/rss.xml"
+  },
+  {
+    "name": "Marcin Wichary",
+    "homepage": "https://aresluna.org/",
+    "feed": "https://aresluna.org/main.rss"
+  },
+  {
+    "name": "Marcy Sutton",
+    "homepage": "https://marcysutton.com/",
+    "feed": "https://marcysutton.com/rss.xml"
+  },
+  {
+    "name": "Marijn Haverbeke",
+    "homepage": "https://marijnhaverbeke.nl/",
+    "feed": "https://marijnhaverbeke.nl/feed.atom"
+  },
+  {
+    "name": "Michael Kibedi",
+    "homepage": "https://www.uxmichael.co/",
+    "feed": "https://www.first-and-fifteenth.co/rss/"
+  },
+  {
+    "name": "Mike Hall",
+    "homepage": "https://skeptic.org.uk/author/mike-hall/",
+    "feed": "https://www.skeptic.org.uk/author/mike-hall/feed/"
+  },
+  {
+    "name": "Monica Dinculescu",
+    "homepage": "https://meowni.ca/",
+    "feed": "https://meowni.ca/atom.xml"
+  },
+  {
+    "name": "Nicholas Zakas",
+    "homepage": "https://humanwhocodes.com/",
+    "feed": "https://humanwhocodes.com/feeds/blog.xml"
+  },
+  {
+    "name": "Olu Niyi-Awosusi",
+    "homepage": "https://olu.online/",
+    "feed": "https://olu.online/feed/?type=rss"
+  },
+  {
+    "name": "Paul Bakaus",
+    "homepage": "https://www.paulbakaus.com/",
+    "feed": "https://www.paulbakaus.com/writing/rss/"
+  },
+  {
+    "name": "Paul Kinlan",
+    "homepage": "https://paul.kinlan.me/",
+    "feed": "https://paul.kinlan.me/index.xml"
+  },
+  {
+    "name": "Paul Lewis",
+    "homepage": "https://aerotwist.com/",
+    "feed": "https://aerotwist.com/blog/feed/"
+  },
+  {
+    "name": "Peter-Paul Koch",
+    "homepage": "https://quirksmode.org/",
+    "feed": "https://quirksmode.org/blog/atom.xml"
+  },
+  {
+    "name": "Phil Hawksworth",
+    "homepage": "https://philhawksworth.dev/",
+    "feed": "https://philhawksworth.dev/feed.xml"
+  },
+  {
+    "name": "Rachel Andrew",
+    "homepage": "https://rachelandrew.co.uk/",
+    "feed": "https://rachelandrew.co.uk/feed/"
+  },
+  {
+    "name": "Rebecca Murphey",
+    "homepage": "https://rmurphey.com/",
+    "feed": "https://rmurphey.com/feed/feed.xml"
+  },
+  {
+    "name": "Remy Sharp",
+    "homepage": "https://remysharp.com/",
+    "feed": "https://remysharp.com/feed.xml"
+  },
+  {
+    "name": "Robert Nyman",
+    "homepage": "https://robertnyman.com/",
+    "feed": "http://feeds.feedburner.com/robertnyman"
+  },
+  {
+    "name": "Ruth John",
+    "homepage": "https://ruthjohn.com/",
+    "feed": "https://blog.rumyra.com/feed.xml"
+  },
+  {
+    "name": "Sacha Judd",
+    "homepage": "https://www.sachajudd.com/",
+    "feed": "https://www.sachajudd.com/feed/"
+  },
+  {
+    "name": "Salma Alam-Naylor",
+    "homepage": "https://whitep4nth3r.com/",
+    "feed": "https://whitep4nth3r.com/feed.xml"
+  },
+  {
+    "name": "Sara Soueidan",
+    "homepage": "https://www.sarasoueidan.com/",
+    "feed": "https://www.sarasoueidan.com/blog/index.xml"
+  },
+  {
+    "name": "Scott Jenson",
+    "homepage": "https://jenson.org/",
+    "feed": "https://jenson.org/feed/"
+  },
+  {
+    "name": "Seb Lee-Delisle",
+    "homepage": "https://seblee.me/",
+    "feed": "https://seblee.me/feed/"
+  },
+  {
+    "name": "Sharon Steed",
+    "homepage": "https://www.communilogue.co/",
+    "feed": "https://www.communilogue.co/blog?format=rss"
+  },
+  {
+    "name": "Simon Willison",
+    "homepage": "https://simonwillison.net/",
+    "feed": "https://simonwillison.net/atom/everything/"
+  },
+  {
+    "name": "Soledad Penadés",
+    "homepage": "https://soledadpenades.com/",
+    "feed": "https://soledadpenades.com/feed"
+  },
+  {
+    "name": "Sophie Koonin",
+    "homepage": "https://localghost.dev/",
+    "feed": "https://localghost.dev/feed.xml"
+  },
+  {
+    "name": "Steven Wittens",
+    "homepage": "https://acko.net/",
+    "feed": "https://acko.net/atom.xml"
+  },
+  {
+    "name": "Stuart Langridge",
+    "homepage": "https://www.kryogenix.org/",
+    "feed": "https://www.kryogenix.org/days/feed/"
+  },
+  {
+    "name": "Surya Rose",
+    "homepage": "https://gearsco.de/",
+    "feed": "https://gearsco.de/blog.xml"
+  },
+  {
+    "name": "Tim Holman",
+    "homepage": "https://tholman.com/",
+    "feed": "https://tholman.com/feed.xml"
+  },
+  {
+    "name": "Tobias Ahlin",
+    "homepage": "https://tobiasahlin.com/",
+    "feed": "https://tobiasahlin.com/feed.xml"
+  }
+]

--- a/src/_data/feeds.json
+++ b/src/_data/feeds.json
@@ -307,7 +307,7 @@
   {
     "name": "Remy Sharp",
     "homepage": "https://remysharp.com/",
-    "feed": "https://remysharp.com/feed.xml"
+    "feed": "https://remysharp.com/blog.xml"
   },
   {
     "name": "Robert Nyman",

--- a/src/_data/latestPosts.json
+++ b/src/_data/latestPosts.json
@@ -1,0 +1,458 @@
+{
+  "http://addyosmani.com/rss.xml": {
+    "title": "Agent Harness Engineering",
+    "url": "https://addyosmani.com/blog/agent-harness-engineering/",
+    "date": "2026-04-19T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://alicebartlett.co.uk/feed.xml": {
+    "title": "Week 398: Fizzy",
+    "url": "https://alicebartlett.co.uk/blog/weaknotes-398",
+    "date": "2026-04-19T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://ada.is/feed": {
+    "title": "Try out your website in the spatial web",
+    "url": "https://webkit.org/blog/15421/try-out-your-website-in-the-spatial-web/",
+    "date": "2024-06-12T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://infrequently.org/feed/": {
+    "title": "The Web Is An Antitrust Wedge",
+    "url": "https://infrequently.org/2026/04/the-web-is-an-antitrust-wedge/",
+    "date": "2026-04-03T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://nesbitt.io/feed.xml": {
+    "title": "brief",
+    "url": "https://nesbitt.io/2026/04/21/brief.html",
+    "date": "2026-04-21T10:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://amyhupe.co.uk/atom.xml": {
+    "title": "Sorry seems to be the most overused word",
+    "url": "https://amyhupe.co.uk/articles/sorry-seems-to-be-the-most-overused-word/",
+    "date": "2026-01-10T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://gericci.me/feed.xml": {
+    "title": "There's No Place Like the Browser",
+    "url": "https://gericci.me/no-place-like-the-browser.html",
+    "date": "2025-11-17T12:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://bell.bz/feed.xml": {
+    "title": "I want an alarm clock",
+    "url": "https://bell.bz/i-want-an-alarm-clock/",
+    "date": "2026-04-01T15:30:16.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://wingolog.org/feed": {
+    "title": "on hayek's bastards",
+    "url": "https://wingolog.org/archives/2026/04/20/on-hayeks-bastards",
+    "date": "2026-04-20T21:35:03.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://javascriptweblog.wordpress.com/feed/": {
+    "title": "Of Classes and Arrow Functions (a cautionary tale)",
+    "url": "https://javascriptweblog.wordpress.com/2015/11/02/of-classes-and-arrow-functions-a-cautionary-tale/",
+    "date": "2015-11-02T14:30:55.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://www.annashipman.co.uk/atom.xml": {
+    "title": "Engineering Productivity in 2026: Where AI Actually Pays Off",
+    "url": "https://www.annashipman.co.uk/jfdi/ai-productivity-panel.html",
+    "date": "2026-02-27T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://goteoc.substack.com/feed": {
+    "title": "What is sustainability?",
+    "url": "https://goteoc.substack.com/p/what-is-sustainability",
+    "date": "2026-02-12T16:05:46.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://bcook.ca/feed/": {
+    "title": "Projects",
+    "url": "https://bcook.ca/projects/",
+    "date": "2025-03-20T23:05:08.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://www.ambershand.co.uk/blog/rss.xml": {
+    "title": "The power of embracing bold action",
+    "url": "https://www.ambershand.co.uk/blog/the-power-of-embracing-bold-action",
+    "date": "2024-02-28T18:14:07.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://brucelawson.co.uk/feed/": {
+    "title": "Reading List 357",
+    "url": "https://brucelawson.co.uk/2026/reading-list-357/",
+    "date": "2026-04-10T15:52:01.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://benjaminbenben.com/atom.xml": {
+    "title": "Offline QR Codes",
+    "url": "https://benjaminbenben.com/2025/08/19/offline-qr-codes/",
+    "date": "2025-08-19T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://charlottedann.com/rss.xml": {
+    "title": "Soft-blob physics",
+    "url": "https://charlottedann.com/article/soft-blob-physics",
+    "date": "2023-10-13T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://caolan.uk/feed/notes/": {
+    "title": "The Story of DOM Patch",
+    "url": "https://caolan.uk/notes/2026-04-16_the_story_of_dom_patch.cm",
+    "date": "2026-04-16T12:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://ohhelloana.blog/feed.xml": {
+    "title": "Offline break in New Forest",
+    "url": "https://ohhelloana.blog/new-forest/",
+    "date": "2026-04-01T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://awfulwoman.com/index.xml": {
+    "title": "Right now",
+    "url": "https://awfulwoman.com/now/",
+    "date": "2025-09-23T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "http://brendandawes.com/blog/feed": {
+    "title": "That Was The Week That Was — 19th April 2026",
+    "url": "http://brendandawes.com/blog/1265-twtwtw-19-apr-2026",
+    "date": "2026-04-19T11:12:15.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://danwebb.net/feed.xml": {
+    "title": "Safety First",
+    "url": "https://danwebb.net/posts/safety-first/",
+    "date": "2025-11-02T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://cwilso.com/feed/": {
+    "title": "Tick.",
+    "url": "https://cwilso.com/2026/04/17/tick-2/",
+    "date": "2026-04-18T00:00:21.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://hannah.wf/rss/": {
+    "title": "Ghost & Ember @ EmberCamp",
+    "url": "https://hannah.wf/embercamp-2015/",
+    "date": "2015-11-04T12:48:49.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://christianheilmann.com/feed/": {
+    "title": "How do developers define their worth when code is written by AI?",
+    "url": "https://christianheilmann.com/2026/04/21/how-do-developers-define-their-worth-when-code-is-written-by-ai/",
+    "date": "2026-04-21T09:22:17.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://csswizardry.com/feed": {
+    "title": "font-family Doesn’t Fall Back the Way You Think",
+    "url": "https://csswizardry.com/2026/04/font-family-doesnt-fall-back-the-way-you-think/",
+    "date": "2026-04-10T11:30:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://joreteg.com/rss": {
+    "title": "Project Fugu: A New Hope",
+    "url": "https://joreteg.com/blog/project-fugu-a-new-hope",
+    "date": "2020-06-11T06:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://heydonworks.com/feed": {
+    "title": "Leveraging The Super Keyword In Custom Elements",
+    "url": "https://heydonworks.com/article/leveraging-the-super-keyword-in-custom-elements/",
+    "date": "2025-12-30T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://bitsofco.de/feed/feed.xml": {
+    "title": "When is :focus-visible visible?",
+    "url": "https://bitsofco.de/when-is-focus-visible-visible/",
+    "date": "2023-03-21T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://adactio.com/journal/rss": {
+    "title": "Dilation",
+    "url": "https://adactio.com/journal/22534",
+    "date": "2026-04-20T09:18:06.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://livelaugh.blog/rss.xml": {
+    "title": "weekly retro #63: there's a lot of depression in this one",
+    "url": "https://livelaugh.blog/posts/weekly-retro-63/",
+    "date": "2026-04-19T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://jakearchibald.com/posts.rss": {
+    "title": "Importing vs fetching JSON",
+    "url": "https://jakearchibald.com/2025/importing-vs-fetching-json/",
+    "date": "2025-10-22T01:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://writing.jan.io/feed.xml": {
+    "title": "Vegan Japan October 2025 Edition",
+    "url": "http://writing.jan.io/2026/02/15/vegan-japan.html",
+    "date": "2026-02-14T23:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://jessica.tech/feed.xml": {
+    "title": "Tech For Good-ish Jobs Jess Found, Feb 2026",
+    "url": "https://jessica.tech/blog/jobslistfeb/",
+    "date": "2026-03-02T14:58:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://www.joehart.co.uk/feed.xml": {
+    "title": "Book Thoughts: Pandora's Star & Judas Unchained by Peter F Hamilton",
+    "url": "https://joehart.co.uk/blogs/book-thoughts-pandoras-star-peter-f-hamilton/",
+    "date": "2026-03-09T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://builtby.kim/feed.xml": {
+    "title": "Best Beauty",
+    "url": "builtby.kim/web%20development/2016/09/03/best-beauty/",
+    "date": "2016-09-03T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://kenneth.io/api/feed.xml": {
+    "title": "Playify - A tool to play your iTunes music in Spotify",
+    "url": "https://kenneth.io/post/playify-a-tool-to-play-your-itunes-music-in-spotify",
+    "date": "2010-02-28T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://medium.com/feed/@jonthanfielding": {
+    "title": "Using GitHub Copilot To Migrate Cookiecutter from Python to Node.js",
+    "url": "https://jonthanfielding.medium.com/using-github-copilot-to-migrate-cookiecutter-from-python-to-node-js-8b70e5f892a7?source=rss-f6c7d7bff0c9------2",
+    "date": "2026-03-08T08:51:21.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://loftio.co.uk/feed/": {
+    "title": "The power of the one day conference",
+    "url": "https://loftio.co.uk/the-power-of-the-one-day-conference/",
+    "date": "2025-05-02T13:50:14.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://webdirections.org/category/blog/feed/": {
+    "title": "Constitutional Prompting: Making AI Coding Agents Reliable Without the Iteration Tax — Prem Pillai at AI Engineer Melbourne 2026",
+    "url": "https://webdirections.org/blog/constitutional-prompting-making-ai-coding-agents-reliable-without-the-iteration-tax-prem-pillai-at-ai-engineer-melbourne-2026/",
+    "date": "2026-04-23T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://lisilinhart.info/feed.xml": {
+    "title": "Five Tips for Joining as a Staff Engineer",
+    "url": "https://lisilinhart.info/posts/joining-as-a-staff-engineer",
+    "date": "2024-11-26T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://maggieappleton.com/rss.xml": {
+    "title": "One Developer, Two Dozen Agents, Zero Alignment",
+    "url": "https://maggieappleton.com/zero-alignment/",
+    "date": "2026-04-13T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://johnkpaul.com/atom.xml": {
+    "title": "Elm Un-googleables",
+    "url": "http://johnkpaul.com/blog/2016/02/16/elm-ungooglables/",
+    "date": "2016-02-16T05:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://tink.uk/feed.xml": {
+    "title": "Tag, you're it",
+    "url": "https://tink.uk/tag-your-it/",
+    "date": "2025-06-15T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://marijnhaverbeke.nl/feed.atom": {
+    "title": "CodeMirror 0.60",
+    "url": "http://groups.google.com/group/codemirror/browse_thread/thread/a61369720512a23c",
+    "date": null,
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://marcysutton.com/rss.xml": {
+    "title": "On Joining Khan Academy",
+    "url": "https://marcysutton.com/on-joining-khan-academy/",
+    "date": "2026-01-30T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://www.first-and-fifteenth.co/rss/": {
+    "title": "Fifteenth #17: On unlearning",
+    "url": "https://www.first-and-fifteenth.co/fifteenth-17-on-unlearning/",
+    "date": "2026-04-15T06:30:15.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://aresluna.org/main.rss": {
+    "title": "System shock",
+    "url": "https://aresluna.org/system-shock",
+    "date": "2026-03-27T15:02:13.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://www.paulbakaus.com/writing/rss/": {
+    "title": "Carving Shaders Out of Claude Code",
+    "url": "https://www.paulbakaus.com/carving-shaders-out-of-claude-code/",
+    "date": "2026-03-26T19:39:28.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://meowni.ca/atom.xml": {
+    "title": "The taxonomy is loose",
+    "url": "https://meowni.ca/posts/taxonomy-is-loose/",
+    "date": "2026-04-13T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://aerotwist.com/blog/feed/": {
+    "title": "The Making of a Logo",
+    "url": "https://aerotwist.com/blog/the-making-of-a-logo/",
+    "date": "2025-01-15T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://olu.online/feed/?type=rss": {
+    "title": "weeknotes #59",
+    "url": "https://olu.online/weeknotes-59/",
+    "date": "2026-03-29T21:30:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://humanwhocodes.com/feeds/blog.xml": {
+    "title": "Improving developer velocity with GitHub merge queue",
+    "url": "https://humanwhocodes.com/blog/2026/04/improving-developer-velocity-github-merge-queue/",
+    "date": "2026-04-06T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://paul.kinlan.me/index.xml": {
+    "title": "<generate-html> Web Component",
+    "url": "https://paul.kinlan.me/projects/generate-html-element/",
+    "date": "2025-12-27T12:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://rachelandrew.co.uk/feed/": {
+    "title": "What would a 2026 CSS Anthology look like?",
+    "url": "https://rachelandrew.co.uk/archives/2026/04/23/what-would-a-2026-css-anthology-look-like/",
+    "date": "2026-04-23T07:40:29.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://rmurphey.com/feed/feed.xml": {
+    "title": "Eng ladders, promotions & glue work",
+    "url": "https://rmurphey.com/posts/eng-ladder-glue-work/",
+    "date": "2021-12-23T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "http://feeds.feedburner.com/robertnyman": {
+    "title": "Four types of people you will come across during your working life",
+    "url": "https://robertnyman.com/2023/12/20/four-types-of-people-you-will-come-across-during-your-working-life/",
+    "date": "2023-12-20T16:24:18.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://www.skeptic.org.uk/author/mike-hall/feed/": {
+    "title": "What little you know about Jack the Ripper’s victims is almost certainly wrong",
+    "url": "https://www.skeptic.org.uk/2025/11/what-little-you-know-about-jack-the-rippers-victims-is-almost-certainly-wrong/",
+    "date": "2025-11-26T10:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://remysharp.com/blog.xml": {
+    "title": "Fixing my slow Mac network speeds",
+    "url": "https://remysharp.com/2026/03/26/fixing-my-slow-mac-network-speeds",
+    "date": "2026-03-26T09:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://blog.rumyra.com/feed.xml": {
+    "title": "Laser Cutting a Jigsaw Puzzle",
+    "url": "https://blog.rumyra.com/2021-01-30-laser-cutting-a-jigsaw-puzzle",
+    "date": "2021-01-30T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://www.sarasoueidan.com/blog/index.xml": {
+    "title": "CSS to speech: alternative text for CSS-generated content",
+    "url": "https://www.sarasoueidan.com/blog/alt-text-for-css-generated-content/",
+    "date": "2025-09-17T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://whitep4nth3r.com/feed.xml": {
+    "title": "I released a song for the first time in 15 years",
+    "url": "https://whitep4nth3r.com/blog/new-electronica-music-manchester-uk/",
+    "date": "2026-04-23T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://finokoye.com/feed/": {
+    "title": "Into the discourse – HYBRID ‘Sowing and Trekking Through Time: Science Fiction Imagines a Revolutionary 2024’",
+    "url": "https://finokoye.com/2024/06/17/into-the-discourse-hybrid-sowing-and-trekking-through-time-science-fiction-imagines-a-revolutionary-2024/",
+    "date": "2024-06-17T22:33:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://jenson.org/feed/": {
+    "title": "The Ma of a New Machine",
+    "url": "https://jenson.org/ma/",
+    "date": "2026-04-13T12:42:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://seblee.me/feed/": {
+    "title": "Review of 2021",
+    "url": "https://seblee.me/2022/09/review-of-2021/",
+    "date": "2022-09-08T09:34:38.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://simonwillison.net/atom/everything/": {
+    "title": "Qwen3.6-27B: Flagship-Level Coding in a 27B Dense Model",
+    "url": "https://simonwillison.net/2026/Apr/22/qwen36-27b/#atom-everything",
+    "date": "2026-04-22T16:45:23.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://www.communilogue.co/blog?format=rss": {
+    "title": "Five Minute Keynote: Compassionate Collaboration",
+    "url": "https://www.communilogue.co/blog/2024/5/7/five-minute-keynote-compassionate-collaboration",
+    "date": "2024-04-02T15:22:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://localghost.dev/feed.xml": {
+    "title": "Stop generating, start thinking",
+    "url": "https://localghost.dev/blog/stop-generating-start-thinking/",
+    "date": "2026-02-08T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://www.kryogenix.org/days/feed/": {
+    "title": "Calculating a rolling average without keeping all the numbers around",
+    "url": "https://www.kryogenix.org/days/2026/03/14/calculating-a-rolling-average-without-keeping-all-the-numbers-around/",
+    "date": "2026-03-14T23:23:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://gearsco.de/blog.xml": {
+    "title": "Building a Blog in Gleam",
+    "url": "https://gearsco.de/blog/blog-in-gleam",
+    "date": "2026-01-20T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://tholman.com/feed.xml": {
+    "title": "Modernized JavaScript 90’s Cursor Effects, that we all know and love",
+    "url": "https://tholman.com/post/cursor-effects/",
+    "date": "2020-07-03T04:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://tobiasahlin.com/feed.xml": {
+    "title": "Responsive type scales with composable CSS utilities",
+    "url": "https://tobiasahlin.com/blog/responsive-fluid-css-type-scales/",
+    "date": "2023-09-22T01:12:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://www.sachajudd.com/feed/": {
+    "title": "ffconf – Brighton",
+    "url": "https://www.sachajudd.com/ffconf-brighton/",
+    "date": "2025-11-14T00:07:44.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://acko.net/atom.xml": {
+    "title": "The L in \"LLM\" Stands for Lying",
+    "url": "https://acko.net/blog/the-l-in-llm-stands-for-lying/",
+    "date": "2026-03-03T23:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://soledadpenades.com/feed": {
+    "title": "Fix files that cannot be deleted in Nextcloud",
+    "url": "https://soledadpenades.com/posts/2025/fix-files-that-cannot-be-deleted-in-nextcloud/",
+    "date": "2025-12-11T13:07:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  },
+  "https://philhawksworth.dev/feed.xml": {
+    "title": "Displaying your full-sized YouTube thumbnail or a custom OG image in a Twitter card",
+    "url": "https://www.hawksworx.com/blog/displaying-your-full-sized-you-tube-thumbnail-or-a-custom-og-image-in-a-twitter-card/",
+    "date": "2023-07-05T00:00:00.000Z",
+    "fetchedAt": "2026-04-23T11:19:19.114Z"
+  }
+}

--- a/src/_data/speakerFeeds.js
+++ b/src/_data/speakerFeeds.js
@@ -1,8 +1,17 @@
+const fs = require('fs');
+const path = require('path');
 const feeds = require('./feeds.json');
 const talks = require('./talks');
 const liveYears = require('../../graphql/data/events.json')
   .filter((_) => _.live !== false)
   .map((_) => _.year);
+
+let latestPosts = {};
+try {
+  latestPosts = JSON.parse(
+    fs.readFileSync(path.join(__dirname, 'latestPosts.json'), 'utf8')
+  );
+} catch {}
 
 const normalise = (s) =>
   (s || '')
@@ -52,6 +61,7 @@ module.exports = async () => {
       bio: talk.speaker.bio || '',
       homepage: feed.homepage,
       feed: feed.feed,
+      latest: latestPosts[feed.feed] || null,
       talk: {
         title: talk.title,
         slug: talk.slug,

--- a/src/_data/speakerFeeds.js
+++ b/src/_data/speakerFeeds.js
@@ -1,0 +1,78 @@
+const feeds = require('./feeds.json');
+const talks = require('./talks');
+const liveYears = require('../../graphql/data/events.json')
+  .filter((_) => _.live !== false)
+  .map((_) => _.year);
+
+const normalise = (s) =>
+  (s || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/&/g, 'and')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+
+module.exports = async () => {
+  const allTalks = (await talks()).filter((t) =>
+    liveYears.includes(parseInt(t.event.year, 10))
+  );
+
+  const feedByName = new Map();
+  for (const f of feeds) {
+    feedByName.set(normalise(f.name), f);
+  }
+
+  const matched = [];
+
+  for (const talk of allTalks) {
+    if (!talk.speaker) continue;
+    const key = normalise(talk.speaker.name);
+    let feed = feedByName.get(key);
+
+    if (!feed) {
+      for (const f of feeds) {
+        const fk = normalise(f.name);
+        if (
+          fk.includes(key) ||
+          key.includes(fk) ||
+          fk.split(' ').every((part) => key.includes(part))
+        ) {
+          feed = f;
+          break;
+        }
+      }
+    }
+
+    if (!feed) continue;
+
+    matched.push({
+      name: talk.speaker.name,
+      photo: talk.speaker.photo,
+      bio: talk.speaker.bio || '',
+      homepage: feed.homepage,
+      feed: feed.feed,
+      talk: {
+        title: talk.title,
+        slug: talk.slug,
+        description: talk.description || '',
+        year: talk.event.year,
+        tags: talk.tags || [],
+      },
+    });
+  }
+
+  matched.sort((a, b) => {
+    if (a.talk.year !== b.talk.year) return b.talk.year - a.talk.year;
+    return a.name.localeCompare(b.name);
+  });
+
+  const years = Array.from(new Set(matched.map((m) => m.talk.year))).sort(
+    (a, b) => b - a
+  );
+  const tags = Array.from(
+    new Set(matched.flatMap((m) => m.talk.tags))
+  ).sort();
+
+  return { entries: matched, years, tags };
+};

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -4,6 +4,20 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="source" content="https://github.com/leftlogic/ffconf">
+    <script>
+      (() => {
+        const q = new URL(location).searchParams.get('font');
+        if (q === 'inter') localStorage.setItem('ffconf-font', 'inter');
+        else if (q !== null) localStorage.removeItem('ffconf-font');
+        if (localStorage.getItem('ffconf-font') === 'inter') {
+          document.documentElement.classList.add('inter');
+          const l = document.createElement('link');
+          l.rel = 'stylesheet';
+          l.href = 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap';
+          document.head.appendChild(l);
+        }
+      })();
+    </script>
     <link rel="preload" href="/fonts/BasierSquare-Medium-custom.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/fonts/BasierSquare-Regular-custom.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="stylesheet" href="/css/base.css">

--- a/src/_includes/navigation.njk
+++ b/src/_includes/navigation.njk
@@ -3,6 +3,7 @@
     <li><a class="shimmer" href="{{ next.url }}"><span class="ext">FFConf {{ next.date | format("YYYY")}}</span></a></li>
     <li{% if page.url.startsWith('/talks/') %} class="selected"{% endif %}><a href="/talks">Talks</a></li>
     <li{% if page.url.startsWith('/articles/') %} class="selected"{% endif %}><a href="/articles">Articles</a></li>
+    <li{% if page.url.startsWith('/feeds') %} class="selected"{% endif %}><a href="/feeds">Feeds</a></li>
     {# <li{% if page.url.startsWith('/jobs/') %} class="selected"{% endif %}><a href="/jobs">Jobs</a></li> #}
     <li{% if page.url.startsWith('/photos/') %} class="selected"{% endif %}><a href="/photos">Photos</a></li>
     <li{% if page.url.startsWith('/posts/') %} class="selected"{% endif %}><a href="/posts">Posts</a></li>

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -1,7 +1,8 @@
 /* custom font with ligature for FFC => ffc */
 @font-face {
   font-family: 'BasierSquare';
-  src: url('/fonts/BasierSquare-Medium-custom.woff2') format('woff2'),
+  src:
+    url('/fonts/BasierSquare-Medium-custom.woff2') format('woff2'),
     url('/fonts/BasierSquare-Medium-custom.woff') format('woff');
   font-weight: 500;
   font-style: normal;
@@ -9,7 +10,8 @@
 
 @font-face {
   font-family: 'BasierSquare';
-  src: url('/fonts/BasierSquare-Regular-custom.woff2') format('woff2'),
+  src:
+    url('/fonts/BasierSquare-Regular-custom.woff2') format('woff2'),
     url('/fonts/BasierSquare-Regular-custom.woff') format('woff');
   font-weight: normal;
   font-style: normal;
@@ -23,6 +25,11 @@
   --box: #f4f4f4;
   --salmon: #ff7063;
   --salmon-dark: #c04001; /* #D95E39;*/
+  --font-family: 'BasierSquare', sans-serif;
+}
+
+html.inter {
+  --font-family: 'Inter', sans-serif;
 }
 
 * {
@@ -47,7 +54,7 @@ strong * {
 /* Text styles */
 
 html {
-  font-family: 'BasierSquare';
+  font-family: var(--font-family);
   scroll-behavior: smooth;
   min-height: 100%;
 }
@@ -146,8 +153,7 @@ h1 + h2 {
   gap: 24px;
 }
 
-.talk .urls a[href^='https://']
-{
+.talk .urls a[href^='https://'] {
   display: inline-block;
   background: url(/images/external-link.svg) no-repeat;
   height: 20px;
@@ -156,8 +162,7 @@ h1 + h2 {
   color: var(--primary);
 }
 
-.talk .urls a[href^="https://twitter.com"]
-{
+.talk .urls a[href^='https://twitter.com'] {
   display: inline-block;
   background: url(/images/twitter.svg) no-repeat;
   height: 20px;
@@ -166,8 +171,7 @@ h1 + h2 {
   color: var(--primary);
 }
 
-.talk .urls a[href^='https://bsky.app/profile/']
-{
+.talk .urls a[href^='https://bsky.app/profile/'] {
   display: inline-block;
   background: url(/images/bsky.svg) no-repeat;
   height: 20px;
@@ -176,8 +180,7 @@ h1 + h2 {
   color: var(--primary);
 }
 
-.talk .urls a[href^='https://www.linkedin.com/in/']
-{
+.talk .urls a[href^='https://www.linkedin.com/in/'] {
   display: inline-block;
   background: url(/images/linkedin.svg) no-repeat;
   height: 20px;
@@ -186,8 +189,7 @@ h1 + h2 {
   color: var(--primary);
 }
 
-.talk .urls a[href^="https://"]:hover
-{
+.talk .urls a[href^='https://']:hover {
   color: var(--salmon);
 }
 
@@ -245,6 +247,7 @@ h1 + h2 {
   /* text-transform: lowercase; */
   padding: 6px 18px;
   display: inline-block;
+  align-content: center;
 }
 
 .pill.active {
@@ -527,7 +530,7 @@ img.soft {
 }
 
 .talk-card p {
-  font-family: BasierSquare;
+  font-family: var(--font-family);
   font-size: 18px;
   font-weight: normal;
   font-style: normal;
@@ -547,7 +550,8 @@ img.soft {
   border: solid 2px var(--salmon);
   background-color: var(--white);
   padding: 8px;
-  background: url(/images/top-grey.svg) no-repeat top right,
+  background:
+    url(/images/top-grey.svg) no-repeat top right,
     url(/images/bottom-grey.svg) no-repeat bottom left;
   background-origin: content-box;
   border-left-width: 0;
@@ -576,7 +580,7 @@ img.soft {
 }
 
 .newsletter h2 {
-  font-family: BasierSquare;
+  font-family: var(--font-family);
   font-size: 32px;
   font-weight: 500;
   line-height: 1.25;

--- a/src/css/feeds.css
+++ b/src/css/feeds.css
@@ -1,0 +1,568 @@
+.feeds {
+  padding: 0 32px 32px 32px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.feeds > header {
+  padding: 0;
+  max-width: 70ch;
+}
+
+.feeds > header h1 {
+  margin: 32px 0 16px 0;
+}
+
+.feeds .intro {
+  color: var(--dark-grey);
+  margin: 0 0 12px 0;
+}
+
+.feeds-missing {
+  color: var(--dark-grey);
+  font-size: 14px;
+  margin: 0 0 32px 0;
+}
+
+.feeds-missing a {
+  color: var(--primary);
+}
+
+.feeds abbr {
+  text-decoration: underline dotted;
+  cursor: help;
+}
+
+.feeds-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: stretch;
+  margin-bottom: 24px;
+}
+
+.feeds-controls .search {
+  flex: 1 1 280px;
+  display: flex;
+  border-radius: 9999px;
+  background-color: var(--box);
+  padding: 4px 20px;
+  align-items: center;
+}
+
+.feeds-controls .search input {
+  flex-grow: 1;
+  background: none;
+  border: 0;
+  font-family: inherit;
+  font-size: 16px;
+  color: var(--primary);
+  padding: 12px 0;
+}
+
+.feeds-controls .search input:focus {
+  outline: none;
+}
+
+.feeds-filter-trigger {
+  background-color: var(--box);
+  color: var(--primary);
+  font-size: 16px;
+  padding: 14px 22px;
+  cursor: pointer;
+}
+
+.feeds-filter-trigger:hover {
+  background-color: var(--light-grey);
+  color: var(--primary);
+}
+
+#trigger-year { anchor-name: --trigger-year; }
+#trigger-tag { anchor-name: --trigger-tag; }
+
+#trigger-year:has(+ #popover-year:popover-open),
+#trigger-tag:has(+ #popover-tag:popover-open) {
+  background-color: var(--salmon);
+  color: white;
+}
+
+.feeds-filter-popover {
+  margin: 0;
+  border: 0;
+  padding: 20px 24px;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 20px 20px 0 rgba(51, 51, 51, 0.2);
+  min-width: 300px;
+  max-width: min(520px, calc(100vw - 40px));
+  color: var(--primary);
+}
+
+.feeds-filter-popover .pill-list {
+  max-height: 320px;
+  overflow-y: auto;
+  margin: 0;
+}
+
+#popover-year .pill-list {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 8px;
+}
+
+#popover-year .checkbox-pill {
+  margin: 0;
+}
+
+#popover-year .pill {
+  font-variant-numeric: tabular-nums;
+  width: 100%;
+  padding: 6px 0;
+  text-align: center;
+}
+
+#popover-year { position-anchor: --trigger-year; }
+#popover-tag { position-anchor: --trigger-tag; }
+
+@supports (anchor-name: --x) {
+  .feeds-filter-popover {
+    position: absolute;
+    inset: auto;
+    top: calc(anchor(bottom) + 8px);
+    right: anchor(right);
+    bottom: auto;
+    left: auto;
+    margin: 0;
+  }
+}
+
+@supports not (anchor-name: --x) {
+  .feeds-filter-popover {
+    inset: auto;
+    top: 20vh;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+}
+
+.feeds-filter-popover::backdrop {
+  background: transparent;
+}
+
+.feeds-summary {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 28px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--light-grey);
+}
+
+.feeds-summary p {
+  margin: 0;
+  color: var(--dark-grey);
+  font-size: 16px;
+}
+
+.feeds-summary #feeds-count,
+.feeds-summary #feeds-selected {
+  color: var(--primary);
+  font-weight: 500;
+}
+
+.feeds-actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.link-button {
+  background: none;
+  border: 0;
+  padding: 6px 0;
+  font-family: inherit;
+  font-size: 16px;
+  color: var(--primary);
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.link-button:hover {
+  color: var(--salmon);
+}
+
+.feeds-actions .pill-button {
+  border: 0;
+  font-family: inherit;
+  padding: 12px 24px;
+  font-size: 16px;
+}
+
+.feeds-actions .pill-button[disabled] {
+  background-color: var(--light-grey);
+  color: var(--dark-grey);
+  cursor: not-allowed;
+}
+
+.feeds-actions .pill-button:not([disabled]):hover {
+  background: var(--salmon-dark);
+}
+
+.feeds-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 24px;
+}
+
+@media (min-width: 720px) {
+  .feeds-list {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.feed-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  grid-template-areas:
+    "photo header"
+    "photo details";
+  align-content: start;
+  gap: 4px 16px;
+  padding: 20px;
+  border: 1px solid var(--light-grey);
+  border-radius: 6px;
+  background: white;
+  transition: border-color 150ms ease-out, box-shadow 150ms ease-out;
+}
+
+.feed-card-photo { grid-area: photo; }
+.feed-card-header { grid-area: header; }
+.feed-card-details { grid-area: details; }
+
+.feed-card:has(input[data-feed]:checked) {
+  border-color: var(--salmon);
+  box-shadow: 0 0 0 1px var(--salmon);
+}
+
+.feed-card-select {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+}
+
+.feed-card-select input {
+  position: absolute;
+  opacity: 0;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.feed-card-select .check {
+  display: block;
+  position: relative;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 2px solid var(--dark-grey);
+  background: white;
+  transition: all 120ms ease-out;
+}
+
+.feed-card-select input:checked + .check {
+  background: var(--salmon);
+  border-color: var(--salmon);
+}
+
+.feed-card-select input:checked + .check::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'><polyline points='5 12 10 17 19 7'/></svg>");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 18px;
+}
+
+.feed-card-select input:focus-visible + .check {
+  outline: 2px solid var(--salmon);
+  outline-offset: 2px;
+}
+
+.feed-card-photo {
+  display: block;
+  width: 100px;
+  height: 100px;
+  border-radius: 4px;
+  background-size: cover;
+  background-position: center;
+  background-color: var(--light-grey);
+  overflow: hidden;
+  text-decoration: none;
+  align-self: start;
+}
+
+.feed-card-photo img {
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.feed-card-header,
+.feed-card-details {
+  min-width: 0;
+}
+
+.feed-card-header {
+  margin-right: 36px;
+}
+
+.feed-card-header h2 {
+  font-size: 20px;
+  font-weight: 500;
+  margin: 0 0 6px 0;
+  color: var(--primary);
+  line-height: 1.2;
+}
+
+.feed-card-header .talk-title {
+  margin: 0 0 12px 0;
+  font-size: 16px;
+  color: var(--primary);
+  line-height: 1.3;
+}
+
+.feed-card-header .talk-prefix {
+  text-transform: uppercase;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--dark-grey);
+  margin-right: 4px;
+  font-weight: 500;
+}
+
+.feed-card-header .talk-title a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.feed-card-header .talk-title a:hover {
+  color: var(--salmon);
+}
+
+.feed-card-header .tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0 0 14px 0;
+}
+
+.feed-card-header .tag-row .pill {
+  font-size: 13px;
+  padding: 4px 12px;
+}
+
+.feed-card-details .speaker-bio {
+  font-size: 14px;
+  line-height: 1.45;
+  color: var(--dark-grey);
+  margin: 8px 0;
+}
+
+details.speaker-bio > summary {
+  list-style: none;
+  cursor: pointer;
+  font-weight: normal;
+}
+
+details.speaker-bio > summary::-webkit-details-marker {
+  display: none;
+}
+
+details.speaker-bio .bio-more {
+  display: none;
+  color: var(--primary);
+  font-weight: 500;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  margin-left: 2px;
+}
+
+details.speaker-bio > summary:hover .bio-more,
+details.speaker-bio > summary:focus-visible .bio-more {
+  display: inline;
+}
+
+details.speaker-bio > summary:hover .bio-more {
+  color: var(--salmon);
+}
+
+details.speaker-bio[open] > summary .bio-preview {
+  display: none;
+}
+
+details.speaker-bio .bio-less {
+  display: none;
+  color: var(--primary);
+  font-weight: 500;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  margin-left: 4px;
+}
+
+details.speaker-bio[open] > summary .bio-less {
+  display: inline;
+}
+
+details.speaker-bio[open] > summary:hover .bio-less {
+  color: var(--salmon);
+}
+
+details.speaker-bio .bio-full {
+  margin: 6px 0 0 0;
+  font-size: 14px;
+  line-height: 1.45;
+  color: var(--dark-grey);
+}
+
+.feed-card-details .feed-links {
+  display: flex;
+  gap: 20px;
+  margin: 14px 0 0 0;
+  font-size: 14px;
+}
+
+.feed-card-details .feed-links a {
+  color: var(--primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.feed-card-details .feed-links a:hover {
+  color: var(--salmon);
+}
+
+.feeds-empty {
+  text-align: center;
+  padding: 60px 20px;
+  color: var(--dark-grey);
+}
+
+@media (max-width: 640px) {
+  .feeds {
+    padding: 0 16px 32px 16px;
+  }
+
+  .feeds-controls {
+    gap: 8px;
+  }
+
+  .feeds-filter-trigger {
+    flex: 1 1 auto;
+    padding: 12px 18px;
+    text-align: center;
+  }
+
+  .feeds-filter-popover {
+    position: fixed;
+    top: auto;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: auto;
+    height: auto;
+    min-width: 0;
+    max-width: none;
+    border-radius: 16px 16px 0 0;
+    box-shadow: 0 -12px 24px 0 rgba(51, 51, 51, 0.25);
+    padding: 24px 20px calc(20px + env(safe-area-inset-bottom));
+    max-height: 70vh;
+    overflow-y: auto;
+    margin: 0;
+    transform: none;
+  }
+
+  .feeds-filter-popover::backdrop {
+    background: rgba(0, 0, 0, 0.4);
+  }
+
+  .feeds-filter-popover .pill-list {
+    max-height: none;
+  }
+
+  .feeds-summary {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .feeds-actions {
+    justify-content: space-between;
+  }
+
+  .feeds-actions .pill-button {
+    flex: 0 0 auto;
+    margin-left: auto;
+  }
+
+  .feed-card {
+    grid-template-columns: 56px 1fr;
+    grid-template-areas:
+      "photo header"
+      "details details";
+    gap: 10px 14px;
+    padding: 16px;
+  }
+
+  .feed-card-header {
+    margin-right: 36px;
+    align-self: center;
+  }
+
+  .feed-card-header h2 {
+    font-size: 17px;
+    margin-bottom: 2px;
+  }
+
+  .feed-card-header .talk-title {
+    font-size: 14px;
+    margin-bottom: 8px;
+  }
+
+  .feed-card-header .tag-row {
+    margin-bottom: 0;
+  }
+
+  .feed-card-photo {
+    width: 56px;
+    height: 56px;
+  }
+
+  .feed-card-details {
+    padding-top: 4px;
+    border-top: 1px solid var(--light-grey);
+    margin-top: 6px;
+  }
+
+  .feed-card-details .speaker-bio {
+    margin: 10px 0 0 0;
+  }
+
+  .feed-card-details .feed-links {
+    gap: 16px;
+    margin-top: 10px;
+    flex-wrap: wrap;
+  }
+}

--- a/src/css/feeds.css
+++ b/src/css/feeds.css
@@ -432,6 +432,43 @@ details.speaker-bio .bio-full {
   color: var(--salmon);
 }
 
+.feed-card-details .latest-post {
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--dark-grey);
+  margin: 8px 0 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  align-items: baseline;
+}
+
+.feed-card-details .latest-label {
+  color: var(--dark-grey);
+  text-transform: uppercase;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  font-weight: 500;
+}
+
+.feed-card-details .latest-post a {
+  color: var(--primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.feed-card-details .latest-post a:hover {
+  color: var(--salmon);
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.feed-card-details .latest-date {
+  color: var(--dark-grey);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
 .feeds-empty {
   text-align: center;
   padding: 60px 20px;

--- a/src/css/feeds.css
+++ b/src/css/feeds.css
@@ -64,89 +64,57 @@
   outline: none;
 }
 
-.feeds-filter-trigger {
+.feeds-filter {
+  margin: 0;
+}
+
+.feeds-filter summary {
+  list-style: none;
+  cursor: pointer;
   background-color: var(--box);
   color: var(--primary);
   font-size: 16px;
   padding: 14px 22px;
-  cursor: pointer;
+  border-radius: 9999px;
+  user-select: none;
+  white-space: nowrap;
 }
 
-.feeds-filter-trigger:hover {
+.feeds-filter summary::-webkit-details-marker {
+  display: none;
+}
+
+.feeds-filter summary::marker {
+  display: none;
+  content: '';
+}
+
+.feeds-filter summary:hover {
   background-color: var(--light-grey);
-  color: var(--primary);
 }
 
-#trigger-year { anchor-name: --trigger-year; }
-#trigger-tag { anchor-name: --trigger-tag; }
-
-#trigger-year:has(+ #popover-year:popover-open),
-#trigger-tag:has(+ #popover-tag:popover-open) {
+.feeds-filter[open] summary {
   background-color: var(--salmon);
   color: white;
 }
 
-.feeds-filter-popover {
-  margin: 0;
-  border: 0;
-  padding: 20px 24px;
+.feeds-filter-body {
   background: white;
+  border: 1px solid var(--light-grey);
   border-radius: 8px;
-  box-shadow: 0 20px 20px 0 rgba(51, 51, 51, 0.2);
-  min-width: 300px;
-  max-width: min(520px, calc(100vw - 40px));
-  color: var(--primary);
+  padding: 20px;
+  margin-bottom: 24px;
+  box-shadow: 0 4px 12px 0 rgba(51, 51, 51, 0.08);
 }
 
-.feeds-filter-popover .pill-list {
-  max-height: 320px;
-  overflow-y: auto;
-  margin: 0;
-}
-
-#popover-year .pill-list {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 8px;
-}
-
-#popover-year .checkbox-pill {
-  margin: 0;
-}
-
-#popover-year .pill {
+.feeds-filter-body .pill-list[data-filter-group='year'] .pill {
   font-variant-numeric: tabular-nums;
-  width: 100%;
-  padding: 6px 0;
-  text-align: center;
 }
 
-#popover-year { position-anchor: --trigger-year; }
-#popover-tag { position-anchor: --trigger-tag; }
-
-@supports (anchor-name: --x) {
-  .feeds-filter-popover {
-    position: absolute;
-    inset: auto;
-    top: calc(anchor(bottom) + 8px);
-    right: anchor(right);
-    bottom: auto;
-    left: auto;
-    margin: 0;
-  }
-}
-
-@supports not (anchor-name: --x) {
-  .feeds-filter-popover {
-    inset: auto;
-    top: 20vh;
-    left: 50%;
-    transform: translateX(-50%);
-  }
-}
-
-.feeds-filter-popover::backdrop {
-  background: transparent;
+.feeds-filter-body .pill-list + .pill-list {
+  border-top: 1px solid var(--light-grey);
+  margin-top: 16px;
+  padding-top: 16px;
 }
 
 .feeds-summary {
@@ -232,20 +200,28 @@
   display: grid;
   grid-template-columns: 100px 1fr;
   grid-template-areas:
-    "photo header"
-    "photo details";
+    'photo header'
+    'photo details';
   align-content: start;
   gap: 4px 16px;
-  padding: 20px;
+  padding: 16px;
   border: 1px solid var(--light-grey);
   border-radius: 6px;
   background: white;
-  transition: border-color 150ms ease-out, box-shadow 150ms ease-out;
+  transition:
+    border-color 80ms ease-out,
+    box-shadow 80ms ease-out;
 }
 
-.feed-card-photo { grid-area: photo; }
-.feed-card-header { grid-area: header; }
-.feed-card-details { grid-area: details; }
+.feed-card-photo {
+  grid-area: photo;
+}
+.feed-card-header {
+  grid-area: header;
+}
+.feed-card-details {
+  grid-area: details;
+}
 
 .feed-card:has(input[data-feed]:checked) {
   border-color: var(--salmon);
@@ -278,7 +254,7 @@
   border-radius: 6px;
   border: 2px solid var(--dark-grey);
   background: white;
-  transition: all 120ms ease-out;
+  transition: all 60ms ease-out;
 }
 
 .feed-card-select input:checked + .check {
@@ -338,7 +314,7 @@
 }
 
 .feed-card-header .talk-title {
-  margin: 0 0 12px 0;
+  margin: 0 0 4px 0;
   font-size: 16px;
   color: var(--primary);
   line-height: 1.3;
@@ -363,23 +339,24 @@
   color: var(--salmon);
 }
 
-.feed-card-header .tag-row {
+.feed-card-details .tag-row {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  margin: 0 0 14px 0;
+  margin: 0 0 8px 0;
 }
 
-.feed-card-header .tag-row .pill {
+.feed-card-details .tag-row .pill {
   font-size: 13px;
   padding: 4px 12px;
+  margin: 0;
 }
 
 .feed-card-details .speaker-bio {
   font-size: 14px;
   line-height: 1.45;
   color: var(--dark-grey);
-  margin: 8px 0;
+  /* margin: 8px 0; */
 }
 
 details.speaker-bio > summary {
@@ -441,7 +418,7 @@ details.speaker-bio .bio-full {
 .feed-card-details .feed-links {
   display: flex;
   gap: 20px;
-  margin: 14px 0 0 0;
+  margin: 8px 0 0 0;
   font-size: 14px;
 }
 
@@ -470,39 +447,6 @@ details.speaker-bio .bio-full {
     gap: 8px;
   }
 
-  .feeds-filter-trigger {
-    flex: 1 1 auto;
-    padding: 12px 18px;
-    text-align: center;
-  }
-
-  .feeds-filter-popover {
-    position: fixed;
-    top: auto;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    width: auto;
-    height: auto;
-    min-width: 0;
-    max-width: none;
-    border-radius: 16px 16px 0 0;
-    box-shadow: 0 -12px 24px 0 rgba(51, 51, 51, 0.25);
-    padding: 24px 20px calc(20px + env(safe-area-inset-bottom));
-    max-height: 70vh;
-    overflow-y: auto;
-    margin: 0;
-    transform: none;
-  }
-
-  .feeds-filter-popover::backdrop {
-    background: rgba(0, 0, 0, 0.4);
-  }
-
-  .feeds-filter-popover .pill-list {
-    max-height: none;
-  }
-
   .feeds-summary {
     flex-direction: column;
     align-items: stretch;
@@ -520,9 +464,9 @@ details.speaker-bio .bio-full {
   .feed-card {
     grid-template-columns: 56px 1fr;
     grid-template-areas:
-      "photo header"
-      "details details";
-    gap: 10px 14px;
+      'photo header'
+      'details details';
+    gap: 8px 14px;
     padding: 16px;
   }
 
@@ -538,11 +482,11 @@ details.speaker-bio .bio-full {
 
   .feed-card-header .talk-title {
     font-size: 14px;
-    margin-bottom: 8px;
+    margin-bottom: 0;
   }
 
-  .feed-card-header .tag-row {
-    margin-bottom: 0;
+  .feed-card-details .tag-row {
+    margin-bottom: 8px;
   }
 
   .feed-card-photo {
@@ -551,9 +495,9 @@ details.speaker-bio .bio-full {
   }
 
   .feed-card-details {
-    padding-top: 4px;
+    padding-top: 8px;
     border-top: 1px solid var(--light-grey);
-    margin-top: 6px;
+    margin-top: 0;
   }
 
   .feed-card-details .speaker-bio {

--- a/src/feeds.njk
+++ b/src/feeds.njk
@@ -1,0 +1,226 @@
+---
+layout: layouts/base.njk
+css: feeds.css
+hide_newsletter: true
+---
+
+<section class="feeds">
+  <header>
+    <h1>Speaker feeds</h1>
+    <p class="intro">Browse speakers from past FFConfs who still publish on their own blog. Filter by year or topic, search by name or session keyword, then download an <abbr title="Outline Processor Markup Language">OPML</abbr> file of the feeds you picked and drop it into your feed reader.</p>
+    <p class="feeds-missing">If your feed is missing, <a href="mailto:events@leftlogic.com?subject=FFConf%20feeds%20page">get in touch</a>.</p>
+  </header>
+
+  <div class="feeds-controls">
+    <label class="search">
+      <span class="visuallyhidden">Search</span>
+      <input id="feeds-search" type="search" placeholder="Search by name, talk, tag or bio…" autocomplete="off">
+    </label>
+
+    <button type="button" id="trigger-year" class="pill-button feeds-filter-trigger" popovertarget="popover-year">Filter by year</button>
+    <div id="popover-year" class="feeds-filter-popover" popover>
+      <div class="pill-list" data-filter-group="year">
+      {% for year in speakerFeeds.years %}
+        <label tabindex="0" class="checkbox-pill"><input value="{{ year }}" type="checkbox" data-year><span class="pill">{{ year }}</span></label>
+      {% endfor %}
+      </div>
+    </div>
+
+    <button type="button" id="trigger-tag" class="pill-button feeds-filter-trigger" popovertarget="popover-tag">Filter by topic</button>
+    <div id="popover-tag" class="feeds-filter-popover" popover>
+      <div class="pill-list" data-filter-group="tag">
+      {% for tag in speakerFeeds.tags %}
+        <label tabindex="0" class="checkbox-pill"><input value="{{ tag }}" type="checkbox" data-tag><span class="pill">{{ tag }}</span></label>
+      {% endfor %}
+      </div>
+    </div>
+  </div>
+
+  <div class="feeds-summary">
+    <p><span id="feeds-count">{{ speakerFeeds.entries | length }}</span> feeds · <span id="feeds-selected">0</span> selected</p>
+    <div class="feeds-actions">
+      <button type="button" class="link-button" id="feeds-select-visible">Select visible</button>
+      <button type="button" class="link-button" id="feeds-clear">Clear selection</button>
+      <button type="button" class="pill-button" id="feeds-download" disabled>Download OPML</button>
+    </div>
+  </div>
+
+  <ol class="feeds-list" id="feeds-list">
+  {% for entry in speakerFeeds.entries %}
+    <li class="feed-card"
+        data-year="{{ entry.talk.year }}"
+        data-tags="{{ entry.talk.tags | join(' | ') | lower }}"
+        data-search="{{ entry.name | lower }} {{ entry.talk.title | lower }} {{ entry.talk.tags | join(' ') | lower }} {{ entry.bio | lower | truncate(400, true, '') }}">
+      <label class="feed-card-select">
+        <input type="checkbox" data-feed data-name="{{ entry.name }}" data-feed-url="{{ entry.feed }}" data-homepage="{{ entry.homepage }}">
+        <span class="check" aria-hidden="true"></span>
+        <span class="visuallyhidden">Include {{ entry.name }} in OPML</span>
+      </label>
+
+      <a class="feed-card-photo" href="/talks/{{ entry.talk.slug }}/" style="background-image: url({{ entry.photo }})" aria-label="View {{ entry.name }}'s talk">
+        <img src="{{ entry.photo }}" alt="" loading="lazy">
+      </a>
+
+      <div class="feed-card-header">
+        <h2>{{ entry.name }}</h2>
+        <p class="talk-title"><span class="talk-prefix">Talk:</span> <a href="/talks/{{ entry.talk.slug }}/">{{ entry.talk.title }}</a></p>
+        <p class="tag-row">
+          <span class="pill active">{{ entry.talk.year }}</span>
+          {% for tag in entry.talk.tags %}<span class="pill">{{ tag }}</span>{% endfor %}
+        </p>
+      </div>
+
+      <div class="feed-card-details">
+        {% if entry.bio %}
+          {% set bioText = entry.bio | striptags(true) %}
+          {% if bioText | length > 120 %}
+        <details class="speaker-bio">
+          <summary><strong>About:</strong> <span class="bio-preview">{{ bioText | truncate(120, true, '') }}…<span class="bio-more">more</span></span><span class="bio-less">show less</span></summary>
+          <p class="bio-full">{{ bioText }}</p>
+        </details>
+          {% else %}
+        <p class="speaker-bio"><strong>About:</strong> {{ bioText }}</p>
+          {% endif %}
+        {% endif %}
+
+        <p class="feed-links">
+          <a href="{{ entry.homepage }}" target="_blank" rel="noopener" class="ext">Homepage</a>
+          <a href="{{ entry.feed }}" target="_blank" rel="noopener" class="ext">RSS feed</a>
+        </p>
+      </div>
+    </li>
+  {% endfor %}
+  </ol>
+
+  <p class="feeds-empty" id="feeds-empty" hidden>No speakers match your filters.</p>
+</section>
+
+<script defer async>
+(() => {
+  const list = $('#feeds-list');
+  const cards = $$('.feed-card');
+  const search = $('#feeds-search');
+  const countEl = $('#feeds-count');
+  const selectedEl = $('#feeds-selected');
+  const downloadBtn = $('#feeds-download');
+  const selectVisibleBtn = $('#feeds-select-visible');
+  const clearBtn = $('#feeds-clear');
+  const emptyEl = $('#feeds-empty');
+
+  const yearBoxes = $$('[data-filter-group="year"] input');
+  const tagBoxes = $$('[data-filter-group="tag"] input');
+  const feedBoxes = $$('input[data-feed]');
+
+  function getChecked(boxes) {
+    return boxes.filter((b) => b.checked).map((b) => b.value.toLowerCase());
+  }
+
+  function applyFilters() {
+    const years = getChecked(yearBoxes);
+    const tags = getChecked(tagBoxes);
+    const q = (search.value || '').trim().toLowerCase();
+
+    let visible = 0;
+    cards.forEach((card) => {
+      const year = card.dataset.year;
+      const cardTags = card.dataset.tags;
+      const haystack = card.dataset.search;
+
+      let match = true;
+      if (years.length && !years.includes(year)) match = false;
+      if (match && tags.length && !tags.some((t) => cardTags.split(' | ').includes(t))) match = false;
+      if (match && q && !haystack.includes(q)) match = false;
+
+      card.hidden = !match;
+      if (match) visible++;
+    });
+
+    countEl.textContent = visible;
+    emptyEl.hidden = visible !== 0;
+  }
+
+  function updateSelected() {
+    const n = feedBoxes.filter((b) => b.checked).length;
+    selectedEl.textContent = n;
+    downloadBtn.disabled = n === 0;
+  }
+
+  function xmlEscape(s) {
+    return String(s || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;');
+  }
+
+  function buildOPML() {
+    const picked = feedBoxes.filter((b) => b.checked);
+    const seen = new Set();
+    const outlines = [];
+    picked.forEach((b) => {
+      const url = b.dataset.feedUrl;
+      if (seen.has(url)) return;
+      seen.add(url);
+      outlines.push(
+        '    <outline type="rss" text="' + xmlEscape(b.dataset.name) +
+        '" title="' + xmlEscape(b.dataset.name) +
+        '" xmlUrl="' + xmlEscape(url) +
+        '" htmlUrl="' + xmlEscape(b.dataset.homepage) + '"/>'
+      );
+    });
+    const now = new Date().toUTCString();
+    return [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<opml version="2.0">',
+      '  <head>',
+      '    <title>FFConf speaker feeds</title>',
+      '    <dateCreated>' + now + '</dateCreated>',
+      '    <ownerName>FFConf</ownerName>',
+      '  </head>',
+      '  <body>',
+      outlines.join('\n'),
+      '  </body>',
+      '</opml>',
+      '',
+    ].join('\n');
+  }
+
+  function download() {
+    const opml = buildOPML();
+    const blob = new Blob([opml], { type: 'text/x-opml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'ffconf-feeds.opml';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+
+  yearBoxes.concat(tagBoxes).forEach((b) => b.addEventListener('change', applyFilters));
+  search.addEventListener('input', applyFilters);
+  feedBoxes.forEach((b) => b.addEventListener('change', updateSelected));
+
+  selectVisibleBtn.addEventListener('click', () => {
+    cards.forEach((card) => {
+      if (!card.hidden) {
+        const cb = card.querySelector('input[data-feed]');
+        if (cb) cb.checked = true;
+      }
+    });
+    updateSelected();
+  });
+
+  clearBtn.addEventListener('click', () => {
+    feedBoxes.forEach((b) => (b.checked = false));
+    updateSelected();
+  });
+
+  downloadBtn.addEventListener('click', download);
+
+  applyFilters();
+  updateSelected();
+})();
+</script>

--- a/src/feeds.njk
+++ b/src/feeds.njk
@@ -72,6 +72,14 @@ hide_newsletter: true
           <a href="{{ entry.homepage }}" target="_blank" rel="noopener" class="ext">Homepage</a>
           <a href="{{ entry.feed }}" target="_blank" rel="noopener" class="ext">RSS feed</a>
         </p>
+
+        {% if entry.latest %}
+        <p class="latest-post">
+          <span class="latest-label">Latest post:</span>
+          <a href="{{ entry.latest.url }}" target="_blank" rel="noopener" class="ext">{{ entry.latest.title }}</a>
+          {% if entry.latest.date %}<time class="latest-date" datetime="{{ entry.latest.date }}">{{ entry.latest.date | format("D MMM YYYY") }}</time>{% endif %}
+        </p>
+        {% endif %}
       </div>
     </li>
   {% endfor %}

--- a/src/feeds.njk
+++ b/src/feeds.njk
@@ -16,23 +16,20 @@ hide_newsletter: true
       <span class="visuallyhidden">Search</span>
       <input id="feeds-search" type="search" placeholder="Search by name, talk, tag or bio…" autocomplete="off">
     </label>
-
-    <button type="button" id="trigger-year" class="pill-button feeds-filter-trigger" popovertarget="popover-year">Filter by year</button>
-    <div id="popover-year" class="feeds-filter-popover" popover>
-      <div class="pill-list" data-filter-group="year">
-      {% for year in speakerFeeds.years %}
-        <label tabindex="0" class="checkbox-pill"><input value="{{ year }}" type="checkbox" data-year><span class="pill">{{ year }}</span></label>
-      {% endfor %}
-      </div>
+    <details class="feeds-filter">
+      <summary class="pill-button" aria-controls="feeds-filter-body"><span class="label">Filter feeds</span></summary>
+    </details>
+  </div>
+  <div class="feeds-filter-body" id="feeds-filter-body" hidden>
+    <div class="pill-list" data-filter-group="year">
+    {% for year in speakerFeeds.years %}
+      <label tabindex="0" class="checkbox-pill"><input value="{{ year }}" type="checkbox" data-year><span class="pill">{{ year }}</span></label>
+    {% endfor %}
     </div>
-
-    <button type="button" id="trigger-tag" class="pill-button feeds-filter-trigger" popovertarget="popover-tag">Filter by topic</button>
-    <div id="popover-tag" class="feeds-filter-popover" popover>
-      <div class="pill-list" data-filter-group="tag">
-      {% for tag in speakerFeeds.tags %}
-        <label tabindex="0" class="checkbox-pill"><input value="{{ tag }}" type="checkbox" data-tag><span class="pill">{{ tag }}</span></label>
-      {% endfor %}
-      </div>
+    <div class="pill-list" data-filter-group="tag">
+    {% for tag in speakerFeeds.tags %}
+      <label tabindex="0" class="checkbox-pill"><input value="{{ tag }}" type="checkbox" data-tag><span class="pill">{{ tag }}</span></label>
+    {% endfor %}
     </div>
   </div>
 
@@ -64,25 +61,13 @@ hide_newsletter: true
       <div class="feed-card-header">
         <h2>{{ entry.name }}</h2>
         <p class="talk-title"><span class="talk-prefix">Talk:</span> <a href="/talks/{{ entry.talk.slug }}/">{{ entry.talk.title }}</a></p>
+      </div>
+
+      <div class="feed-card-details">
         <p class="tag-row">
           <span class="pill active">{{ entry.talk.year }}</span>
           {% for tag in entry.talk.tags %}<span class="pill">{{ tag }}</span>{% endfor %}
         </p>
-      </div>
-
-      <div class="feed-card-details">
-        {% if entry.bio %}
-          {% set bioText = entry.bio | striptags(true) %}
-          {% if bioText | length > 120 %}
-        <details class="speaker-bio">
-          <summary><strong>About:</strong> <span class="bio-preview">{{ bioText | truncate(120, true, '') }}…<span class="bio-more">more</span></span><span class="bio-less">show less</span></summary>
-          <p class="bio-full">{{ bioText }}</p>
-        </details>
-          {% else %}
-        <p class="speaker-bio"><strong>About:</strong> {{ bioText }}</p>
-          {% endif %}
-        {% endif %}
-
         <p class="feed-links">
           <a href="{{ entry.homepage }}" target="_blank" rel="noopener" class="ext">Homepage</a>
           <a href="{{ entry.feed }}" target="_blank" rel="noopener" class="ext">RSS feed</a>
@@ -110,6 +95,11 @@ hide_newsletter: true
   const yearBoxes = $$('[data-filter-group="year"] input');
   const tagBoxes = $$('[data-filter-group="tag"] input');
   const feedBoxes = $$('input[data-feed]');
+  const filterToggle = $('.feeds-filter');
+  const filterBody = $('#feeds-filter-body');
+  filterToggle.addEventListener('toggle', () => {
+    filterBody.hidden = !filterToggle.open;
+  });
 
   function getChecked(boxes) {
     return boxes.filter((b) => b.checked).map((b) => b.value.toLowerCase());


### PR DESCRIPTION
Joins the feeds JSON (speakers who still publish) with live talk data so visitors can browse speakers by year or topic, search by name or session keyword, and download an OPML file of the feeds they pick to drop into a feed reader. Uses the native Popover API with anchor positioning for filter dropdowns (falls back to a bottom sheet on mobile), and a native <details> element for expanding truncated speaker bios.